### PR TITLE
Fix non-functional button to multiclick

### DIFF
--- a/src/Classes/ButtonCollector.js
+++ b/src/Classes/ButtonCollector.js
@@ -53,7 +53,7 @@ class ButtonCollector extends Collector {
     this.checkEnd();
   }
 
-  endReason() {
+  get endReason() {
     if (this.options.max && this.total >= this.options.max) return 'limit';
     return null;
   }


### PR DESCRIPTION
You have to add the get property to the endReason otherwise the bot will go to the collector.on(end) as soon as the user's first click ends without waiting for the time limit to expire