### PR TITLE
Add .setEmoji to MessageButton

### DIFF
--- a/src/Classes/MessageButton.js
+++ b/src/Classes/MessageButton.js
@@ -53,12 +53,11 @@ class MessageButton {
         return this;
     }
 
-    setEmoji(emojiName, emojiID) {
-        emojiName = resolveString(emojiName);
-        emojiID = resolveString(emojiID);
+    setEmoji(emoji) {
+        emoji = resolveString(emoji);
 
-        if (isEmoji(emojiName) === true) this.emoji = { name: emojiName }
-        else if (emojiID.length > 0) this.emoji = { name: emojiName, id: emojiID }
+        if (isEmoji(emoji) === true) this.emoji = { name: emoji }
+        else if (emoji.length > 0) this.emoji = { id: emoji }
         else this.emoji = { name: null, id: null };
         return this;
     }

--- a/src/Classes/MessageButton.js
+++ b/src/Classes/MessageButton.js
@@ -54,10 +54,9 @@ class MessageButton {
     }
 
     setEmoji(emoji) {
-        emoji = resolveString(emoji);
-
-        if (isEmoji(emoji) === true) this.emoji = { name: emoji }
-        else if (emoji.length > 0) this.emoji = { id: emoji }
+        if (isEmoji(resolveString(emoji)) === true) this.emoji = { name: resolveString(emoji) }
+        else if (emoji.id) this.emoji = { id: emoji.id }
+        else if (resolveString(emoji).length > 0) this.emoji = { id: resolveString(emoji) }
         else this.emoji = { name: null, id: null };
         return this;
     }

--- a/src/Classes/MessageButton.js
+++ b/src/Classes/MessageButton.js
@@ -53,7 +53,7 @@ class MessageButton {
         return this;
     }
 
-    setEmoji({emojiName, emojiID}) {
+    setEmoji(emojiName, emojiID) {
         emojiName = resolveString(emojiName);
         emojiID = resolveString(emojiID);
 

--- a/src/Classes/MessageButton.js
+++ b/src/Classes/MessageButton.js
@@ -1,4 +1,4 @@
-const { resolveStyle } = require('../Util');
+const { resolveStyle, isEmoji } = require('../Util');
 const { resolveString } = require('discord.js').Util;
 
 class MessageButton {
@@ -53,11 +53,22 @@ class MessageButton {
         return this;
     }
 
+    setEmoji({emojiName, emojiID}) {
+        emojiName = resolveString(emojiName);
+        emojiID = resolveString(emojiID);
+
+        if (isEmoji(emojiName) === true) this.emoji = { name: emojiName }
+        else if (emojiID.length > 0) this.emoji = { name: emojiName, id: emojiID }
+        else this.emoji = { name: null, id: null };
+        return this;
+    }
+
     toJSON() {
         return {
             type: 2,
             style: this.style,
             label: this.label,
+            emoji: this.emoji,
             disabled: this.disabled,
             url: this.url,
             custom_id: this.custom_id

--- a/src/Util.js
+++ b/src/Util.js
@@ -19,7 +19,7 @@ module.exports = {
 
         if (!data.style) throw new TypeError('NO_BUTTON_STYLE: Please provide button style');
 
-        if (!data.label) throw new TypeError('NO_BUTTON_LABEL: Please provide button label');
+        if (!data.label && !data.emoji) throw new TypeError('NO_BUTTON_LABEL_AND_EMOJI: Please provide button label and/or emoji');
 
         if (data.style === 5) {
             if (!data.url) throw new TypeError('NO_BUTTON_URL: You provided url style, you must provide an URL');

--- a/src/Util.js
+++ b/src/Util.js
@@ -27,8 +27,8 @@ module.exports = {
             if (!data.custom_id) throw new TypeError('NO_BUTTON_ID: Please provide button id');
         }
 
-        if (data.emoji.id) {
-            if (isNaN(data.emoji.id)) throw new TypeError('INCORRECT_BUTTON_ID: Please provide correct button id');
+        if (data.emoji) {
+            if (isNaN(data.emoji.id)) throw new TypeError('INCORRECT_EMOJI_ID: Please provide correct emoji id');
         }
 
         return {

--- a/src/Util.js
+++ b/src/Util.js
@@ -28,7 +28,7 @@ module.exports = {
         }
 
         if (data.emoji) {
-            if (isNaN(data.emoji.id) && !this.isEmoji(data.emoji.name)) throw new TypeError('INCORRECT_EMOJI_ID: Please provide correct emoji id');
+            if (isNaN(data.emoji ? data.emoji.id : 0) && !this.isEmoji(data.emoji.name)) throw new TypeError('INCORRECT_EMOJI_ID: Please provide correct emoji id');
         }
 
         return {

--- a/src/Util.js
+++ b/src/Util.js
@@ -27,6 +27,10 @@ module.exports = {
             if (!data.custom_id) throw new TypeError('NO_BUTTON_ID: Please provide button id');
         }
 
+        if (data.emoji.id) {
+            if (isNaN(data.emoji.id)) throw new TypeError('INCORRECT_BUTTON_ID: Please provide correct button id');
+        }
+
         return {
             style: data.style,
             label: data.label,

--- a/src/Util.js
+++ b/src/Util.js
@@ -30,6 +30,7 @@ module.exports = {
         return {
             style: data.style,
             label: data.label,
+            emoji: data.emoji,
             disabled: Boolean(data.disabled),
             url: data.url,
             custom_id: data.custom_id,
@@ -44,5 +45,10 @@ module.exports = {
         } else {
             return false;
         }
+    },
+      
+    isEmoji(string) {
+        var regex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|\ud83c[\ude32-\ude3a]|\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/g;
+        return regex.test(string)
     }
 }

--- a/src/Util.js
+++ b/src/Util.js
@@ -28,7 +28,7 @@ module.exports = {
         }
 
         if (data.emoji) {
-            if (isNaN(data.emoji.id)) throw new TypeError('INCORRECT_EMOJI_ID: Please provide correct emoji id');
+            if (isNaN(data.emoji.id) && !this.isEmoji(data.emoji.name)) throw new TypeError('INCORRECT_EMOJI_ID: Please provide correct emoji id');
         }
 
         return {


### PR DESCRIPTION
### This PR introduce the .setEmoji() function.

### Usage :

unicode emoji :
```js
const button = new MessageButton()
    .setStyle('gray')
    .setLabel('‏‏‎click')
    .setID('button1')
    .setEmoji('🎉')
```
    
custom emoji :
```js
const button = new MessageButton()
    .setStyle('gray')
    .setLabel('‏‏‎click')
    .setID('button1')
    .setEmoji("703289496434770011")

const emoji = client.emojis.cache.get("703289496434770011")

const button = new MessageButton()
    .setStyle('gray')
    .setLabel('‏‏‎click')
    .setID('button1')
    .setEmoji(emoji)

const button = new MessageButton()
    .setStyle('gray')
    .setLabel('‏‏‎click')
    .setID('button1')
    .setEmoji({ id: "703289496434770011" })
```

You can also send button with only emoji (no label) :
```js
const button = new MessageButton()
    .setStyle('gray')
    .setID('button1')
    .setEmoji('🎉')
```