### PR TITLE
Bypass d.js user cache if not found.

### DIFF
--- a/src/Classes/INTERACTION_CREATE.js
+++ b/src/Classes/INTERACTION_CREATE.js
@@ -26,7 +26,7 @@ class ButtonEvent {
 
         if (this.guild) {
             this.clicker.member = this.guild.members.resolve(data.member.user.id);
-            this.clicker.user = this.client.users.resolve(data.member.user.id);
+            this.clicker.user = this.client.users.resolve(data.member.user.id) || data.member.user;;
         } else {
             this.clicker.user = this.client.users.resolve(data.user.id);
         }


### PR DESCRIPTION
This isn't the most elegant of solution but it works enough to get you the user id if they're not already cached with your bot.