### PR TITLE
Make the user ID directly accessible in clicker

### DIFF
--- a/src/v12/Classes/clickButton.js
+++ b/src/v12/Classes/clickButton.js
@@ -23,6 +23,7 @@ class MessageComponent {
         this.channel = client.channels.cache.get(data.channel_id);
 
         this.clicker = {
+            id: data.guild_id ? data.member.user.id : data.user.id,
             user: this.client.users.resolve(data.guild_id ? data.member.user.id : data.user.id),
             member: this.guild ? this.guild.members.resolve(data.member.user.id) : undefined,
             fetch: async () => {


### PR DESCRIPTION
Some bots may not have the correct intents to resolve user data (they will be null). Still having the user ID of the executing user may be handy for some bots to still be able to use.